### PR TITLE
Fix: fixed npm install typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Thank to :
 ## Installation 
 [npm package](https://www.npmjs.com/package/@simerca/vue2-leaflet-marker-canvas)
 
-`npm i @simerca/vue2-leaflet-canvas-marker`
+`npm i @simerca/vue2-leaflet-marker-canvas`
 
 ## Use
 


### PR DESCRIPTION
previously _npm i @simerca/vue2-leaflet-canvas-marker_ I changed it to _npm i @simerca/vue2-leaflet-marker-canvas_ because there was a typo